### PR TITLE
Scaffold site with devcontainer and Pages workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,25 @@
+{
+  "name": "battle-realm-site",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {}
+  },
+  "postCreateCommand": "corepack enable && pnpm i || npm i",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "editor.formatOnSave": true,
+        "files.eol": "\n"
+      },
+      "extensions": [
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  },
+  "remoteEnv": {
+    "SITE_NAME": "Battle Realm",
+    "NODE_ENV": "development"
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# --- Site ---
+SITE_NAME=Battle Realm
+SITE_URL=https://<your-username>.github.io/Battle-Realm
+SITE_TAGLINE=Build decks. Command creatures. Dominate the realm.
+
+# --- Analytics (optional) ---
+GA_MEASUREMENT_ID=G-XXXXXXXXXX      # Google Analytics 4
+PLAUSIBLE_DOMAIN=battle-realm.site   # If you prefer Plausible (self-host or SaaS)
+
+# --- Email / newsletter (optional) ---
+MAILERLITE_API_KEY=YOUR_KEY
+MAILCHIMP_API_KEY=YOUR_KEY
+NEWSLETTER_FORM_ACTION=/api/subscribe
+
+# --- Media CDN (optional) ---
+CLOUDINARY_CLOUD_NAME=YOUR_NAME
+CLOUDINARY_API_KEY=YOUR_KEY
+CLOUDINARY_API_SECRET=YOUR_SECRET
+
+# --- Error monitoring (optional) ---
+SENTRY_DSN=YOUR_DSN
+
+# --- Content generation (optional) ---
+OPENAI_API_KEY=YOUR_KEY
+
+# --- Build flags ---
+NODE_ENV=production

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require review for workflows and env
+.github/workflows/*   @your-handle
+.devcontainer/*       @your-handle

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,59 @@
+name: Deploy static site to GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Build
+        env:
+          SITE_NAME: ${{ secrets.SITE_NAME }}
+          SITE_URL: ${{ secrets.SITE_URL }}
+          GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
+          MAILERLITE_API_KEY: ${{ secrets.MAILERLITE_API_KEY }}
+          MAILCHIMP_API_KEY: ${{ secrets.MAILCHIMP_API_KEY }}
+          CLOUDINARY_CLOUD_NAME: ${{ secrets.CLOUDINARY_CLOUD_NAME }}
+          CLOUDINARY_API_KEY: ${{ secrets.CLOUDINARY_API_KEY }}
+          CLOUDINARY_API_SECRET: ${{ secrets.CLOUDINARY_API_SECRET }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: npm run build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ rad.json
 *.flf
 #Test results file
 TestResults.xml
+# Node and environment
+node_modules/
+.env

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Battle Realm</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "battle-realm-site",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --strictPort --port 4321",
+    "test": "echo 'no tests'"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,9 @@
+interface ImportMetaEnv {
+  readonly SITE_NAME: string
+  readonly SITE_URL: string
+  readonly SITE_TAGLINE: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,7 @@
+const app = document.getElementById('app')
+
+if (app) {
+  const name = import.meta.env.SITE_NAME || 'Battle Realm'
+  const tagline = import.meta.env.SITE_TAGLINE || ''
+  app.innerHTML = `<h1>${name}</h1><p>${tagline}</p>`
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  envPrefix: ['VITE_', 'SITE_'],
+})


### PR DESCRIPTION
## Summary
- add Node 20 devcontainer with pnpm/npm setup and editor defaults
- provide `.env.example` for site, analytics, and optional services
- set up GitHub Pages workflow and CODEOWNERS
- scaffold minimal Vite site consuming environment variables

## Testing
- `npm test`
- `npm run build` *(fails: vite not found - npm install 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a32a3e9740832185ca505b4962e746