### PR TITLE
Add God Tier creature list

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
       <a href="#about">About</a>
       <a href="#cards">Cards</a>
       <a href="#rules">Rules</a>
+      <a href="#god-tier">God Tier</a>
       <a href="#play">Play</a>
     </nav>
   </header>
@@ -76,6 +77,63 @@
       <li>Take turns drawing and playing cards.</li>
       <li>Use creatures, spells, equipment, and locations strategically.</li>
       <li>The goal: reduce your opponent’s health to zero.</li>
+    </ul>
+  </section>
+
+  <!-- God Tier Creatures -->
+  <section id="god-tier">
+    <h2>God Tier Creatures</h2>
+    <ul>
+      <li>Chronomancer</li>
+      <li>Sun Elemental</li>
+      <li>Cthulhu</li>
+      <li>Blaze Phoenix</li>
+      <li>Nidhogg</li>
+      <li>Maltheal - The Timeshifter</li>
+      <li>Dragon Deity</li>
+      <li>Tatiana - Queen of Dragons</li>
+      <li>Null Entity</li>
+      <li>Phoenix Emperor</li>
+      <li>Norn’s Priestess</li>
+      <li>Serendipity Angel</li>
+      <li>Ancient Mara</li>
+      <li>Onyx Sphinx</li>
+      <li>Infernogorgon</li>
+      <li>Infernum Beast</li>
+      <li>Cerberus Andante</li>
+      <li>Elven Champion</li>
+      <li>Lornezo Ogaara - The Ruthless Scourge</li>
+      <li>Scarab Ichor (also known as Scarabix)</li>
+      <li>Hellion Squierarch</li>
+      <li>Dhera I’ fharuos</li>
+      <li>Crouch Corche</li>
+      <li>Creature Rosheacalor</li>
+      <li>Capito Abondiendang</li>
+      <li>Australopithecized Slug Lion</li>
+      <li>Lindmakeriva</li>
+      <li>Galmraheratus</li>
+      <li>Srachnursinear</li>
+      <li>Vifisport</li>
+      <li>Bunk Taillzin</li>
+      <li>Rockamegvorack</li>
+      <li>Galormidios Stoken</li>
+      <li>Basnokscoracle</li>
+      <li>Kragh Mestr</li>
+      <li>Gertoeisiean Erahmark</li>
+      <li>Mechagorazareal</li>
+      <li>Lucifeanama</li>
+      <li>Beatalistria Tekra</li>
+      <li>Obsidianravzarion</li>
+      <li>Kaleidisnappgarischon</li>
+      <li>Gerbarithbroge</li>
+      <li>Varniomantax</li>
+      <li>Frauggeroncen</li>
+      <li>Brutalidio</li>
+      <li>Temptrewyfernajir</li>
+      <li>Mortrendmeyorhurde</li>
+      <li>Infernumphloriousae</li>
+      <li>Aingholauphlesgrauphol</li>
+      <li>Jenitzscheragon</li>
     </ul>
   </section>
 


### PR DESCRIPTION
## Summary
- add navigation link for God Tier section
- list 50 God tier creatures on homepage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4678a62e08321aef5c35bad367bbd