### PR TITLE
Add missing configuration and location data

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,26 @@
+# --- Site ---
+SITE_NAME=Battle Realm
+SITE_URL=https://BattleRealm.github.io/Battle-Realm
+SITE_TAGLINE=Build decks. Command creatures. Dominate the realm.
+
+# --- Analytics (optional) ---
+GA_MEASUREMENT_ID=G-XXXXXXXXXX
+PLAUSIBLE_DOMAIN=battle-realm.site
+
+# --- Newsletter (optional) ---
+MAILERLITE_API_KEY=YOUR_KEY
+MAILCHIMP_API_KEY=YOUR_KEY
+
+# --- Media CDN (optional) ---
+CLOUDINARY_CLOUD_NAME=YOUR_NAME
+CLOUDINARY_API_KEY=YOUR_KEY
+CLOUDINARY_API_SECRET=YOUR_SECRET
+
+# --- Error monitoring (optional) ---
+SENTRY_DSN=YOUR_DSN
+
+# --- Content generation (optional) ---
+OPENAI_API_KEY=YOUR_KEY
+
+# --- Build flags ---
+NODE_ENV=production

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   <link rel="icon" type="image/png" href="favicon.png" />
 </head>
 <body>
+  <div id="app"></div>
   <!-- Header -->
   <header>
     <h1>🃏 Battle Realm</h1>
@@ -144,12 +145,13 @@
       The game is currently in development. Watch this space for print-and-play
       decks and online playtest links!
     </p>
-    <a href="https://github.com/<your-username>/Battle-Realm" class="btn">View on GitHub</a>
+    <a href="https://github.com/BattleRealm/Battle-Realm" class="btn">View on GitHub</a>
   </section>
 
   <!-- Footer -->
   <footer>
     <p>&copy; 2025 Battle Realm. Licensed under CC BY-NC-SA 4.0.</p>
   </footer>
+  <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/src/locations.ts
+++ b/src/locations.ts
@@ -1,0 +1,11 @@
+export const locations = [
+  'Frozen Citadel',
+  'Lava Gorge',
+  'Elven Glade',
+  'Thaumaturgic Towers',
+  'Abyssal Pit',
+  'Sacred Vault',
+  'Sky Castle',
+];
+
+export default locations;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- Wire HTML to boot the TypeScript entry point and link to the correct GitHub repo
- Add environment variables, TypeScript config, and location card data

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a469a78ad48321afb542d7d92c26e7