### PR TITLE
Add simple server engine and client integration

### DIFF
--- a/server/game-engine.ts
+++ b/server/game-engine.ts
@@ -1,0 +1,69 @@
+export interface PlayerState {
+  id: string;
+  health: number;
+  hand: string[];
+  field: string[];
+}
+
+export interface GameState {
+  players: Record<string, PlayerState>;
+  turn: string;
+}
+
+/**
+ * Very small in-memory game engine that performs basic move validation.
+ * The server should be the single source of truth for the game state and
+ * only expose validated state to clients.
+ */
+export class GameEngine {
+  public state: GameState;
+
+  constructor() {
+    this.state = {
+      players: {
+        p1: { id: 'p1', health: 20, hand: ['card1', 'card2'], field: [] },
+        p2: { id: 'p2', health: 20, hand: ['card1', 'card2'], field: [] }
+      },
+      turn: 'p1'
+    };
+  }
+
+  playCard(playerId: string, card: string): GameState {
+    const player = this.state.players[playerId];
+    if (!player) {
+      throw new Error('Unknown player');
+    }
+    if (this.state.turn !== playerId) {
+      throw new Error('Not your turn');
+    }
+    const idx = player.hand.indexOf(card);
+    if (idx === -1) {
+      throw new Error('Card not in hand');
+    }
+    player.hand.splice(idx, 1);
+    player.field.push(card);
+    this.endTurn();
+    return this.state;
+  }
+
+  attack(attackerId: string, targetId: string): GameState {
+    const attacker = this.state.players[attackerId];
+    const target = this.state.players[targetId];
+    if (!attacker || !target) {
+      throw new Error('Unknown player');
+    }
+    if (this.state.turn !== attackerId) {
+      throw new Error('Not your turn');
+    }
+    if (attacker.field.length === 0) {
+      throw new Error('No creatures to attack with');
+    }
+    target.health -= 1;
+    this.endTurn();
+    return this.state;
+  }
+
+  private endTurn(): void {
+    this.state.turn = this.state.turn === 'p1' ? 'p2' : 'p1';
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,50 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { GameEngine } from './game-engine.js';
+
+const engine = new GameEngine();
+
+function parseBody(req: IncomingMessage): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => (data += chunk));
+    req.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+function send(res: ServerResponse, code: number, payload: any) {
+  res.statusCode = code;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(payload));
+}
+
+const server = createServer(async (req, res) => {
+  if (!req.url || req.method !== 'POST') {
+    send(res, 404, { error: 'Not found' });
+    return;
+  }
+  try {
+    const body = await parseBody(req);
+    let state;
+    if (req.url === '/play-card') {
+      state = engine.playCard(body.playerId, body.card);
+    } else if (req.url === '/attack') {
+      state = engine.attack(body.attackerId, body.targetId);
+    } else {
+      send(res, 404, { error: 'Not found' });
+      return;
+    }
+    send(res, 200, { state });
+  } catch (err: any) {
+    send(res, 400, { error: err.message });
+  }
+});
+
+const PORT = Number(process.env.PORT) || 3000;
+server.listen(PORT);
+console.log(`Server listening on http://localhost:${PORT}`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,51 @@
-const app = document.getElementById('app')
+const app = document.getElementById('app');
+
+async function post(path: string, payload: any) {
+  const res = await fetch(`http://localhost:3000${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || 'Request failed');
+  }
+  return res.json();
+}
+
+function renderState(target: HTMLElement, state: any) {
+  target.textContent = JSON.stringify(state, null, 2);
+}
 
 if (app) {
-  const name = import.meta.env.SITE_NAME || 'Battle Realm'
-  const tagline = import.meta.env.SITE_TAGLINE || ''
-  app.innerHTML = `<h1>${name}</h1><p>${tagline}</p>`
+  const name = import.meta.env.SITE_NAME || 'Battle Realm';
+  const tagline = import.meta.env.SITE_TAGLINE || '';
+  app.innerHTML = `<h1>${name}</h1><p>${tagline}</p>`;
+
+  const statePre = document.createElement('pre');
+  app.appendChild(statePre);
+
+  const playBtn = document.createElement('button');
+  playBtn.textContent = 'Play Card';
+  playBtn.onclick = async () => {
+    try {
+      const { state } = await post('/play-card', { playerId: 'p1', card: 'card1' });
+      renderState(statePre, state);
+    } catch (err: any) {
+      alert(err.message);
+    }
+  };
+  app.appendChild(playBtn);
+
+  const attackBtn = document.createElement('button');
+  attackBtn.textContent = 'Attack';
+  attackBtn.onclick = async () => {
+    try {
+      const { state } = await post('/attack', { attackerId: 'p1', targetId: 'p2' });
+      renderState(statePre, state);
+    } catch (err: any) {
+      alert(err.message);
+    }
+  };
+  app.appendChild(attackBtn);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "server/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- implement minimal game engine on the server with move validation
- expose REST endpoints for playing cards and attacking
- update client to send actions to server and display validated state

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4718641688321a66113d931f7040a