### PR TITLE
Add JWT session handling and client auth flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,13 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview --strictPort --port 4321",
-    "test": "echo 'no tests'"
+    "test": "echo 'no tests'",
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "jsonwebtoken": "^9.0.2"
   },
   "devDependencies": {
     "vite": "^5.0.0"

--- a/server.js
+++ b/server.js
@@ -1,0 +1,75 @@
+import express from 'express';
+import cors from 'cors';
+import jwt from 'jsonwebtoken';
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const SECRET = process.env.JWT_SECRET || 'dev-secret';
+
+// Simple in-memory user store
+const users = {
+  player1: { password: 'password' }
+};
+
+// Session store keeps nonce and game state per user
+const sessions = {};
+
+function generateToken(username) {
+  return jwt.sign({ username }, SECRET, { expiresIn: '15m' });
+}
+
+app.post('/login', (req, res) => {
+  const { username, password } = req.body;
+  const user = users[username];
+  if (!user || user.password !== password) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  sessions[username] = { nonce: 0, gameState: {} };
+  const token = generateToken(username);
+  res.json({ token });
+});
+
+function authMiddleware(req, res, next) {
+  const header = req.headers.authorization;
+  if (!header) {
+    return res.status(401).json({ error: 'Missing token' });
+  }
+  const token = header.split(' ')[1];
+  try {
+    const payload = jwt.verify(token, SECRET);
+    req.user = payload.username;
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+app.post('/game/action', authMiddleware, (req, res) => {
+  const { nonce, action } = req.body;
+  const session = sessions[req.user];
+  if (!session) {
+    return res.status(401).json({ error: 'No active session' });
+  }
+  if (nonce !== session.nonce + 1) {
+    return res.status(409).json({ error: 'Invalid nonce' });
+  }
+  session.nonce = nonce;
+  session.gameState.lastAction = action;
+  res.json({ ok: true, state: session.gameState });
+});
+
+app.post('/refresh', authMiddleware, (req, res) => {
+  const token = generateToken(req.user);
+  res.json({ token });
+});
+
+app.post('/logout', authMiddleware, (req, res) => {
+  delete sessions[req.user];
+  res.json({ ok: true });
+});
+
+app.listen(3000, () => {
+  console.log('Server listening on port 3000');
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,3 +5,81 @@ if (app) {
   const tagline = import.meta.env.SITE_TAGLINE || ''
   app.innerHTML = `<h1>${name}</h1><p>${tagline}</p>`
 }
+
+// --- Basic client-side auth demo ---
+let token = localStorage.getItem('token') || ''
+let nonce = 0
+
+const authRoot = document.createElement('div')
+authRoot.innerHTML = `
+  <form id="login-form">
+    <input id="username" placeholder="username" required />
+    <input id="password" type="password" placeholder="password" required />
+    <button type="submit">Login</button>
+  </form>
+  <button id="action-btn" disabled>Send Action</button>
+  <button id="refresh-btn" disabled>Refresh Token</button>
+  <button id="logout-btn" disabled>Logout</button>
+`
+document.body.appendChild(authRoot)
+
+function setLoggedIn(state: boolean) {
+  (document.getElementById('action-btn') as HTMLButtonElement).disabled = !state
+  (document.getElementById('refresh-btn') as HTMLButtonElement).disabled = !state
+  (document.getElementById('logout-btn') as HTMLButtonElement).disabled = !state
+}
+
+setLoggedIn(!!token)
+
+document.getElementById('login-form')?.addEventListener('submit', async (e) => {
+  e.preventDefault()
+  const username = (document.getElementById('username') as HTMLInputElement).value
+  const password = (document.getElementById('password') as HTMLInputElement).value
+  const res = await fetch('http://localhost:3000/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  })
+  if (res.ok) {
+    const data = await res.json()
+    token = data.token
+    localStorage.setItem('token', token)
+    nonce = 0
+    setLoggedIn(true)
+  }
+})
+
+document.getElementById('action-btn')?.addEventListener('click', async () => {
+  nonce += 1
+  await fetch('http://localhost:3000/game/action', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ nonce, action: 'test' }),
+  })
+})
+
+document.getElementById('refresh-btn')?.addEventListener('click', async () => {
+  const res = await fetch('http://localhost:3000/refresh', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (res.ok) {
+    const data = await res.json()
+    token = data.token
+    localStorage.setItem('token', token)
+  }
+})
+
+document.getElementById('logout-btn')?.addEventListener('click', async () => {
+  await fetch('http://localhost:3000/logout', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  token = ''
+  nonce = 0
+  localStorage.removeItem('token')
+  setLoggedIn(false)
+})


### PR DESCRIPTION
## Summary
- add Express server with JWT login, refresh, logout and protected game action endpoint
- persist per-session game state with nonce to block replay
- implement client-side login, logout and token refresh helpers

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4718ce468832194b1974f1f531d9d